### PR TITLE
Use property= for Open Graph meta tags

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -73,12 +73,10 @@ const pageDescription = excerpt || description || site.description;
         <meta property="og:title" content={title}>
         <meta property="og:type" content={type}>
         <meta property="og:url" content={`${site.baseUrl}${path}`}>
-        {pageDescription && (
-          <meta property="og:description" content={pageDescription}>
-        )}
-        {ogImageUrl && (
+        {ogImageUrl && excerpt && (
           <>
             <meta property="og:image" content={ogImageUrl}>
+            <meta property="og:description" content={excerpt}>
             <meta name="twitter:card" content="summary_large_image">
           </>
         )}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -44,7 +44,6 @@ const pageDescription = excerpt || description || site.description;
 ---
 
 <meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <title>{pageTitle}</title>
@@ -71,13 +70,15 @@ const pageDescription = excerpt || description || site.description;
     <link rel="canonical" href={`${site.baseUrl}${path}`}>
     {type === 'article' && (
       <>
-        <meta name="og:title" content={title}>
-        <meta name="og:type" content={type}>
-        <meta name="og:url" content={`${site.baseUrl}${path}`}>
-        {ogImageUrl && excerpt && (
+        <meta property="og:title" content={title}>
+        <meta property="og:type" content={type}>
+        <meta property="og:url" content={`${site.baseUrl}${path}`}>
+        {pageDescription && (
+          <meta property="og:description" content={pageDescription}>
+        )}
+        {ogImageUrl && (
           <>
-            <meta name="og:image" content={ogImageUrl}>
-            <meta name="og:description" content={excerpt}>
+            <meta property="og:image" content={ogImageUrl}>
             <meta name="twitter:card" content="summary_large_image">
           </>
         )}


### PR DESCRIPTION
## Problem

`src/components/Head.astro` has two meta-tag problems on `main`:

1. Open Graph tags used `<meta name="og:...">` instead of `<meta property="og:...">` (lines 74-80 on `main`). The Open Graph protocol requires the `property` attribute; several scrapers ignore `name=` for these tags. (`twitter:card` correctly used `name=` already and is left unchanged.)
2. `<meta http-equiv="X-UA-Compatible" content="IE=edge">` (line 47) is a long-obsolete IE compatibility directive with no effect in any current browser.

## What changed

In `src/components/Head.astro`:
- All `og:*` meta tags now use `property=` instead of `name=` (`og:title`, `og:type`, `og:url`, `og:image`, `og:description`). `twitter:card` still uses `name=`, per spec.
- Removed the obsolete `<meta http-equiv="X-UA-Compatible" content="IE=edge">` tag.

The social sharing preview (`og:image` + `og:description` + `twitter:card`) is still gated on the original `{ogImageUrl && excerpt}` condition — it renders only when an article has both a poster image and an explicit excerpt. This coupling is intentional: a preview card should only appear when both pieces are deliberately set.

No other structure changed — the `isPrivate`/`path`/`type === 'article'` conditionals are untouched.

> **Note:** An earlier revision of this PR decoupled `og:image` from `excerpt` and emitted `og:description` from `pageDescription` (falling back to `site.description`). That was reverted — per the author's intent, the social preview should appear only when both an image and an excerpt are explicitly set. The description above reflects the current diff.

## Verification

- `npm run lint` — 0 errors.
- `npm run types:check` — `astro check` + `tsc --noEmit`, 0 errors.
- `npm run test:unit` — all unit tests passed.
- `npm run build` — succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
