### PR TITLE
Build alerts with textContent instead of innerHTML interpolation

### DIFF
--- a/src/javascript/alerts.test.ts
+++ b/src/javascript/alerts.test.ts
@@ -38,4 +38,28 @@ describe('alerts', () => {
     expect(els).toHaveLength(2);
     expect(els[0]!.id).not.toBe(els[1]!.id);
   });
+
+  it('renders title and body as literal text, never as HTML', () => {
+    delete (window as unknown as {__pwned?: boolean}).__pwned;
+
+    const maliciousTitle = '<b>Bold Title</b>';
+    const maliciousBody = '<img src=x onerror="window.__pwned=true">';
+
+    alerts.add({title: maliciousTitle, body: maliciousBody});
+
+    const alert = document.querySelector<HTMLElement>('.Alert')!;
+    const titleEl = alert.querySelector('.Alert-title')!;
+    const messageEl = alert.querySelector('.Alert-message')!;
+
+    // The strings must be shown verbatim as text, not parsed as markup.
+    expect(titleEl.textContent).toBe(maliciousTitle);
+    expect(messageEl.textContent).toBe(maliciousBody);
+
+    // No elements should have been created from the interpolated strings.
+    expect(titleEl.querySelector('b')).toBeNull();
+    expect(messageEl.querySelector('img')).toBeNull();
+
+    // The onerror handler must never have executed.
+    expect((window as unknown as {__pwned?: boolean}).__pwned).toBeUndefined();
+  });
 });

--- a/src/javascript/alerts.ts
+++ b/src/javascript/alerts.ts
@@ -13,19 +13,38 @@ export const add = ({title, body}: AlertOptions) => {
     className: 'Alert',
     id: id,
     popover: 'auto',
-    innerHTML: `
-      <div class="Alert-icon">
-        ${renderIcon('error-outline')}
-      </div>
-      <div class="Alert-body">
-        <h1 class="Alert-title">${title}</h1>
-        <div class="Alert-message">${body}</div>
-      </div>
-      <button class="Alert-close" popovertarget=${id}>
-        ${renderIcon('close')}
-      </button>
-    `,
   });
+
+  const icon = Object.assign(document.createElement('div'), {
+    className: 'Alert-icon',
+    innerHTML: renderIcon('error-outline'),
+  });
+
+  const alertTitle = Object.assign(document.createElement('h1'), {
+    className: 'Alert-title',
+  });
+  alertTitle.textContent = title;
+
+  const message = Object.assign(document.createElement('div'), {
+    className: 'Alert-message',
+  });
+  message.textContent = body;
+
+  const alertBody = Object.assign(document.createElement('div'), {
+    className: 'Alert-body',
+  });
+  alertBody.appendChild(alertTitle);
+  alertBody.appendChild(message);
+
+  const close = Object.assign(document.createElement('button'), {
+    className: 'Alert-close',
+    innerHTML: renderIcon('close'),
+  });
+  close.setAttribute('popovertarget', id);
+
+  alert.appendChild(icon);
+  alert.appendChild(alertBody);
+  alert.appendChild(close);
 
   alert.addEventListener('toggle', (event: ToggleEvent) => {
     const toggleEvent = event;


### PR DESCRIPTION
## Problem
`src/javascript/alerts.ts` (`add()`) interpolates `title` and `body` directly into an `innerHTML` template string (lines 16–27 on `main`). `body` in particular can carry server-influenced content: `src/javascript/content-loader.ts:48-51` calls `alerts.add({title, body})` with `body` set to either a network-error message or `` `Response: (${response.status}) ${response.statusText}` `` (content-loader.ts:31) — i.e. a string reflecting the fetch response, unescaped, straight into `innerHTML`. The template also emits `popovertarget=${id}` unquoted.

Practical exploitability here is low (the server controls `statusText`/error text today), but it's a real injectable sink and cheap to close off.

## Root cause
`Object.assign(document.createElement('div'), { innerHTML: \`...${title}...${body}...\` })` parses the interpolated strings as HTML instead of treating them as text.

## What changed
`src/javascript/alerts.ts`: rebuilt `add()` to construct the DOM with `createElement`/`appendChild` instead of one `innerHTML` template:
- `title` is set via `alertTitle.textContent = title` on the `h1.Alert-title`.
- `body` is set via `message.textContent = body` on the `div.Alert-message`.
- `popovertarget` is set via `close.setAttribute('popovertarget', id)` instead of unquoted interpolation.
- The icon SVGs (`renderIcon('error-outline')`, `renderIcon('close')`) are still assigned via `innerHTML`, but that markup is static — `renderIcon` is only ever called with literal icon-id strings from this file, never with `title`/`body`.
- DOM shape, class names (`Alert`, `Alert-icon`, `Alert-body`, `Alert-title`, `Alert-message`, `Alert-close`), and behavior (popover, `toggle` → `transitionend`/`transitioncancel` → `remove`) are unchanged — verified by diffing the old template against the new element tree.

`src/javascript/alerts.test.ts`: added a test that passes an HTML-looking title and a `body` containing `<img src=x onerror="window.__pwned=true">`, and asserts:
- the rendered `.Alert-title`/`.Alert-message` `textContent` equals the raw strings verbatim,
- no `<b>`/`<img>` element was created from them,
- `window.__pwned` was never set (i.e. no script execution).

I temporarily reverted `alerts.ts` to the old `innerHTML` implementation (keeping the new test) and confirmed the new test fails against it:
```
AssertionError: expected 'Bold Title' to be '<b>Bold Title</b>'
```
then restored the fix and reran — it passes.

`src/javascript/messages.ts` has the identical `innerHTML` interpolation pattern (`body` and `action` strings), but it's slated for deletion in PR #101 (`fix/remove-messages`). I left it untouched per instructions. **If #101 is not merged, `messages.ts` should get the same `textContent`-based treatment.**

## Verification
- `npm run lint` — 0 errors.
- `npm run types:check` (astro check + tsc) — 0 errors (pre-existing unrelated warnings in `src/worker/performance.test.ts` about deprecated `env` from `cloudflare:test`, not touched by this change).
- `npm run test:unit` — 16 test files, 68 tests passed (vitest node + worker + browser projects), including the new browser-project test in `alerts.test.ts`.
- `npm run build` — astro build succeeded, 48 pages built.
- Did not run full e2e per task instructions (unit tests in the real-browser vitest project are the right verification for this DOM-construction change).

## Codex review
Ran `git diff origin/main...HEAD | codex exec --sandbox read-only --ephemeral ...`. Verdict: **APPROVE**, no blocking issues. Two low-severity non-blocking suggestions:
1. The `window.__pwned` assertion is a weaker backstop signal in some test environments than the DOM/textContent checks above it (not applicable here since the browser-project tests run in real Chrome via webdriver, so `onerror` firing is a meaningful signal — but I agree the textContent/querySelector assertions are the primary proof).
2. Consider also deleting `window.__pwned` in `afterEach` so a failed assertion can't leak the global into later tests. Left as-is since it's low-value cleanup for a single test file; happy to add if desired.

## Please scrutinize
- I kept `innerHTML` for the two icon SVGs (`Alert-icon`, `Alert-close` contents) since `renderIcon()` only ever receives static, code-controlled icon-id strings (`'error-outline'`, `'close'`) — never `title`/`body`. Confirm you're comfortable with that split rather than avoiding `innerHTML` entirely in this file.
- Confirm the `messages.ts` note above matches your plan for PR #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)