### PR TITLE
Unify SVG icons behind an Icon component and drop xlink:href

### DIFF
--- a/src/components/ArticleContent.astro
+++ b/src/components/ArticleContent.astro
@@ -3,6 +3,7 @@
  * Shared article content component used by both ArticleLayout and
  * ArticlePartialLayout to avoid duplication.
  */
+import Icon from './Icon.astro';
 
 interface Props {
   title: string;
@@ -62,9 +63,7 @@ const blueskyShareUrl = `https://bsky.app/intent/compose?text=${encodeURICompone
   <footer class="entry-unrelated">
     <div id="share" class="Share">
       <span class="Share-figure">
-        <svg class="Icon" viewBox="0 0 32 32">
-          <use xlink:href="#icon-bsky-butterfly"></use>
-        </svg>
+        <Icon id="bsky-butterfly" viewBox="0 0 32 32" />
       </span>
       <p class="Share-pitch">
         If you liked this article and think others should read it, please

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  id: string;
+  viewBox?: string;
+}
+
+const {id, viewBox = '0 0 24 24'} = Astro.props;
+---
+
+<svg class="Icon" viewBox={viewBox}>
+  <use href={`#icon-${id}`}></use>
+</svg>

--- a/src/javascript/utils/renderIcon.test.ts
+++ b/src/javascript/utils/renderIcon.test.ts
@@ -5,6 +5,7 @@ describe('renderIcon', () => {
   it('returns SVG markup referencing the icon by ID', () => {
     const markup = renderIcon('close');
     expect(markup).toContain('<svg class="Icon"');
-    expect(markup).toContain('xlink:href="#icon-close"');
+    expect(markup).toContain('href="#icon-close"');
+    expect(markup).not.toContain('xlink:href');
   });
 });

--- a/src/javascript/utils/renderIcon.ts
+++ b/src/javascript/utils/renderIcon.ts
@@ -3,6 +3,5 @@
  */
 export const renderIcon = (id: string): string => {
   return `<svg class="Icon" viewBox="0 0 24 24">
-    <use xmlns:xlink="http://www.w3.org/1999/xlink"
-         xlink:href="#icon-${id}"></use></svg>`;
+    <use href="#icon-${id}"></use></svg>`;
 };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import Head from '../components/Head.astro';
+import Icon from '../components/Icon.astro';
 import Icons from '../components/Icons.astro';
 
 // Import CSS - main.css is critical, defer.css is for non-critical styles
@@ -53,19 +54,13 @@ const props = Astro.props;
     </a>
     <nav class="Header-social">
       <a class="Header-socialLink" href="https://bsky.app/profile/philipwalton.com" title="Bluesky" style="--fill:#0f73ff">
-        <svg class="Icon" viewBox="0 0 32 32">
-          <use xlink:href="#icon-bsky"></use>
-        </svg>
+        <Icon id="bsky" viewBox="0 0 32 32" />
       </a>
       <a class="Header-socialLink" href="https://github.com/philipwalton" title="Github" style="--fill:#111">
-        <svg class="Icon" viewBox="0 0 32 32">
-          <use xlink:href="#icon-github"></use>
-        </svg>
+        <Icon id="github" viewBox="0 0 32 32" />
       </a>
       <a class="Header-socialLink" href="http://feeds.feedburner.com/philipwalton" title="RSS" style="--fill:#f93">
-        <svg class="Icon" viewBox="0 0 32 32">
-          <use xlink:href="#icon-rss"></use>
-        </svg>
+        <Icon id="rss" viewBox="0 0 32 32" />
       </a>
     </nav>
     <nav class="Header-nav">


### PR DESCRIPTION
## Problem

The icon system was split three ways with two conventions:
- `src/components/Icons.astro` defines the SVG sprite (`<symbol>`/`<g>` defs).
- `src/javascript/utils/renderIcon.ts` builds `<svg class="Icon" viewBox="0 0 24 24"><use xlink:href="#icon-...">` markup strings for JS-created DOM (used by `alerts.ts`).
- `src/layouts/Layout.astro` (3 header social icons) and `src/components/ArticleContent.astro` (bsky-butterfly share icon) hand-inlined `<svg class="Icon" viewBox="0 0 32 32"><use xlink:href="...">` blocks.

All of these used the deprecated `xlink:href` attribute on `<use>`, when plain `href` has worked in every browser for years.

## Root cause

The icon rendering logic was duplicated across a JS string-builder and two Astro templates instead of going through one shared component, so each copy independently carried the outdated `xlink:href` convention.

## What changed

- Added `src/components/Icon.astro`: a small component with props `id: string` and optional `viewBox` (default `'0 0 24 24'`), rendering `<svg class="Icon" viewBox={viewBox}><use href={`#icon-${id}`} /></svg>`.
  - Chose an explicit `viewBox` prop over a baked-in id→grid lookup table inside `Icon.astro`. The sprite only has two grids (24-unit and 32-unit) split cleanly by call site — all `Icon.astro` usages in Layout/ArticleContent are 32-unit, all `renderIcon.ts` usages are 24-unit (the default). A lookup table would just duplicate that same fact in a second place; passing `viewBox` explicitly at 32-unit call sites keeps the component trivial and keeps the "which grid is this icon on" fact next to the one place that already needs it, without adding an id-keyed map to keep in sync as icons are added.
- Replaced the hand-inlined `<svg>` blocks in `Layout.astro` (bsky/github/rss header icons) and `ArticleContent.astro` (bsky-butterfly share icon) with `<Icon id="..." viewBox="0 0 32 32" />`. The `--fill` inline style on the parent `<a>` (which controls icon color via `fill: currentColor`) is untouched since it lives on the wrapping element, not the icon markup itself.
- Updated `renderIcon.ts` to emit plain `href="#icon-${id}"` and dropped the now-unnecessary `xmlns:xlink` attribute.
- Updated `renderIcon.test.ts` to assert plain `href` and the absence of `xlink:href`.
- Grepped all of `src/` and `test/` for remaining `xlink` references (excluding unrelated `.svg` image assets under `src/images/`) — confirmed only the four files above referenced it, all now fixed. `alerts.test.ts` doesn't assert on icon markup, so it needed no changes.

## Verification

- `npm run lint` — 0 errors.
- `npm run types:check` — `astro check` + `tsc --noEmit`, 0 errors, 0 warnings (6 pre-existing unrelated hints about `cloudflare:test` env deprecation).
- `npm run test:unit` — 16 test files, 67 tests passed, no unhandled errors.
- `npm run build` — 48 pages built successfully.
- Built this branch and `origin/main` separately and diffed the rendered header/share `<svg>` markup on a representative article page (`dist/articles/solved-by-flexbox/index.html`). The only attribute-level differences are `xlink:href="#icon-*"` → `href="#icon-*"` on the 4 affected icons; `viewBox`, `class="Icon"`, and the parent `--fill` styles are byte-identical. The only other diff in the full-page comparison is the content-hashed script filename, which changes because `Layout.astro`'s source changed (not a markup regression).
- Full E2E was not required for this task (lint/types/unit/build + dist verification only, per task scope).

## Codex review

Ran `git diff origin/main...HEAD | codex exec --sandbox read-only --ephemeral ...`. Verdict: **APPROVE**, no blocking issues. Non-blocking suggestions (not addressed, out of scope for this fix):
- Consider validating/sanitizing `id` in `renderIcon.ts` against a safe pattern in case a future caller ever passes non-constant input (today all callers pass string literals).
- Consider `aria-hidden="true"`/`focusable="false"` defaults on decorative icons for accessibility (pre-existing behavior, unchanged by this PR).
- Dropping `xlink:href` intentionally forgoes legacy SVG 1.1 / old-browser compatibility, per the task's explicit request.

## Please scrutinize

- The choice of explicit `viewBox` prop vs. an id→grid lookup table in `Icon.astro` (see "What changed" above) — I judged the prop approach cleaner given only two grids exist, but this is a matter of taste.
- **Sibling PR conflict**: PR #111 (`fix/alert-escaping`) has rewritten `alerts.ts`/`alerts.test.ts` on its own branch off `origin/main`. This branch only touched `renderIcon.ts`/`renderIcon.test.ts` (not `alerts.ts`/`alerts.test.ts`, which needed no xlink-related changes since they don't assert on icon markup). No conflict expected, but whichever of #111 or this PR merges second should double check `renderIcon` call sites still line up after rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)