### PR TITLE
Add the missing xl breakpoint to the JS breakpoints list

### DIFF
--- a/src/css/base/variables.css
+++ b/src/css/base/variables.css
@@ -25,6 +25,8 @@
   --error-color: hsl(0, 60%, 50%);
 }
 
+/* Keep these breakpoints in sync with the breakpoints list in src/javascript/breakpoints.ts. */
+
 /* Breakpoint: MD*/
 @media (min-width: 36em) {
   :root {

--- a/src/javascript/breakpoints.test.ts
+++ b/src/javascript/breakpoints.test.ts
@@ -3,7 +3,7 @@ import {page} from 'vitest/browser';
 import {getActiveBreakpoint, init} from './breakpoints.ts';
 
 // Breakpoints from src/javascript/breakpoints.ts, at 16px per em:
-// sm = all, md = 36em (576px), lg = 48em (768px).
+// sm = all, md = 36em (576px), lg = 48em (768px), xl = 60em (960px).
 it('tracks the active breakpoint across viewport changes', async () => {
   await page.viewport(500, 700);
   init();
@@ -14,6 +14,9 @@ it('tracks the active breakpoint across viewport changes', async () => {
 
   await page.viewport(800, 700);
   await expect.poll(() => getActiveBreakpoint().name).toBe('lg');
+
+  await page.viewport(1000, 700);
+  await expect.poll(() => getActiveBreakpoint().name).toBe('xl');
 
   await page.viewport(500, 700);
   await expect.poll(() => getActiveBreakpoint().name).toBe('sm');

--- a/src/javascript/breakpoints.ts
+++ b/src/javascript/breakpoints.ts
@@ -4,10 +4,12 @@ interface Breakpoint {
   mql?: MediaQueryList;
 }
 
+// Keep these values in sync with the breakpoint media queries in src/css/base/variables.css.
 export const breakpoints: Breakpoint[] = [
   {name: 'sm', media: 'all'},
   {name: 'md', media: '(min-width: 36em)'},
   {name: 'lg', media: '(min-width: 48em)'},
+  {name: 'xl', media: '(min-width: 60em)'},
 ];
 
 // Set a default initially, which will be overridden at `init()` time


### PR DESCRIPTION
## Problem

Breakpoints are duplicated between CSS and JS and have already drifted. `src/css/base/variables.css` defines media-query breakpoints at 36em (MD), 48em (LG), and 60em (XL), but `src/javascript/breakpoints.ts:7-11` only defined `sm`/`md`/`lg` — the `xl` breakpoint was missing entirely. As a result the analytics `breakpoint` user param (set from `getActiveBreakpoint().name` in `src/javascript/Logger.ts:69`) could never report `xl`, even though the CSS treats it as a distinct layout state.

## Root cause

The two breakpoint lists (CSS media queries and the JS `breakpoints` array) are maintained by hand in separate files with no shared source of truth, and the JS list simply never got the `xl` entry added when it was introduced in CSS.

## What changed

This is a deliberately minimal fix — a full single-source-of-truth refactor (e.g. generating one list from the other, or restructuring the `mql` handling) was considered and explicitly deferred:

- Added `{name: 'xl', media: '(min-width: 60em)'}` to the `breakpoints` array in `src/javascript/breakpoints.ts`.
- Added a one-line cross-reference comment above the array pointing at `src/css/base/variables.css`, and a mirrored one-liner above the breakpoint media-query blocks in `variables.css` pointing back at `breakpoints.ts`.
- Extended `src/javascript/breakpoints.test.ts` to also assert the `xl` breakpoint becomes active at a 1000px viewport width (960px = 60em breakpoint), matching the existing pattern for sm/md/lg.

No changes to the `mql` handling logic — a sibling PR (`fix/js-cleanups`) restructures that, so expect a trivial conflict in `breakpoints.ts` when rebasing.

## Analytics impact — please decide

This changes the possible values of the analytics `breakpoint` user param: viewports ≥60em will now start reporting `'xl'` instead of `'lg'`. **Flagging for the author:** do you want to bump `MEASUREMENT_VERSION` in `src/javascript/log.ts` (currently `99`) to mark this schema change? I did not bump it myself since that's a judgment call about your analytics pipeline.

## Verification

- `npm run lint` — 0 errors
- `npm run types:check` (astro check + tsc) — 0 errors (pre-existing unrelated `env` deprecation hints in `src/worker/performance.test.ts`)
- `npm run test:unit` — 16 test files / 67 tests passed, including the extended browser-project `breakpoints.test.ts`
- `npm run build` — succeeded, 48 pages built
- E2E not run per task instructions (lint/types/unit/build only)

## Codex review

Verdict: **APPROVE**. Two non-blocking, low-severity suggestions:
1. Consider adding boundary-value coverage (e.g. 959px vs 960px) to the xl test to catch off-by-one/unit-sync regressions.
2. Comment-based sync between CSS and JS can still drift in the future; consider a test asserting the JS list matches the CSS media queries, or centralizing the definitions.

Both are consistent with the "deliberately minimal fix" scope from the task and are left for a potential future refactor rather than addressed here.

## Please scrutinize

- Whether `MEASUREMENT_VERSION` should be bumped (see above) — this is the main judgment call needed from the author.
- `src/css/base/variables.css` is also touched by PRs #105/#113 (color tokens / dark theme) on other branches. My addition is a single comment line at the top of the media-query section at the bottom of the file, so any merge conflict should be trivial to resolve.
- `src/javascript/breakpoints.ts` will also be touched by `fix/js-cleanups` (mql handling restructure) — expect a small conflict there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)