### PR TITLE
Extract a renderPartialResponse helper for the four partial endpoints

### DIFF
--- a/src/pages/about/index.prtl.ts
+++ b/src/pages/about/index.prtl.ts
@@ -1,30 +1,12 @@
 import type {APIRoute} from 'astro';
-import {experimental_AstroContainer as AstroContainer} from 'astro/container';
-import {loadRenderers} from 'astro:container';
-import {getContainerRenderer as getMDXRenderer} from '@astrojs/mdx/container-renderer';
 import PagePartialLayout from '../../layouts/PagePartialLayout.astro';
 import AboutContent from '../../components/AboutContent.astro';
+import {renderPartialResponse} from '../../utils/renderPartial.ts';
 
 export const GET: APIRoute = async () => {
-  const renderers = await loadRenderers([getMDXRenderer()]);
-  const container = await AstroContainer.create({renderers});
-
-  // Render the shared AboutContent component
-  const aboutHtml = await container.renderToString(AboutContent);
-
-  // Render the partial layout with the about content as slot
-  const html = await container.renderToString(PagePartialLayout, {
-    props: {
-      title: 'About',
-    },
-    slots: {
-      default: aboutHtml,
-    },
-  });
-
-  return new Response(html, {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-    },
-  });
+  return renderPartialResponse(
+    PagePartialLayout,
+    {title: 'About'},
+    AboutContent,
+  );
 };

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -1,14 +1,9 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import ArticleLayout from '../../layouts/ArticleLayout.astro';
+import { getArticleStaticPaths } from '../../utils/articles.ts';
 
-export async function getStaticPaths() {
-  const articles = await getCollection('articles');
-  return articles.map((article) => ({
-    params: { slug: article.id },
-    props: { article },
-  }));
-}
+export const getStaticPaths = getArticleStaticPaths;
 
 const { article } = Astro.props;
 const { Content, remarkPluginFrontmatter } = await render(article);

--- a/src/pages/articles/[...slug]/index.prtl.ts
+++ b/src/pages/articles/[...slug]/index.prtl.ts
@@ -1,47 +1,23 @@
-import type {APIRoute, GetStaticPaths} from 'astro';
-import {getCollection, render} from 'astro:content';
-import {experimental_AstroContainer as AstroContainer} from 'astro/container';
-import {loadRenderers} from 'astro:container';
-import {getContainerRenderer as getMDXRenderer} from '@astrojs/mdx/container-renderer';
+import type {APIRoute} from 'astro';
+import {render, type CollectionEntry} from 'astro:content';
 import ArticlePartialLayout from '../../../layouts/ArticlePartialLayout.astro';
+import {renderPartialResponse} from '../../../utils/renderPartial.ts';
+import {getArticleStaticPaths} from '../../../utils/articles.ts';
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const articles = await getCollection('articles');
-  return articles.map((article) => ({
-    params: {slug: article.id},
-    props: {article},
-  }));
-};
+export const getStaticPaths = getArticleStaticPaths;
 
 export const GET: APIRoute = async ({props}) => {
-  const {article} = props as {
-    article: Awaited<ReturnType<typeof getCollection>>[number];
-  };
+  const {article} = props as {article: CollectionEntry<'articles'>};
   const {Content} = await render(article);
 
-  // Create container with MDX renderer
-  const renderers = await loadRenderers([getMDXRenderer()]);
-  const container = await AstroContainer.create({renderers});
-
-  // Render the Content component to get the MDX HTML
-  const contentHtml = await container.renderToString(Content);
-
-  // Render the full partial layout with the content as a slot
-  const html = await container.renderToString(ArticlePartialLayout, {
-    props: {
+  return renderPartialResponse(
+    ArticlePartialLayout,
+    {
       title: article.data.title,
       date: new Date(article.data.date),
       path: `/articles/${article.id}/`,
       translations: article.data.translations,
     },
-    slots: {
-      default: contentHtml,
-    },
-  });
-
-  return new Response(html, {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-    },
-  });
+    Content,
+  );
 };

--- a/src/pages/articles/index.prtl.ts
+++ b/src/pages/articles/index.prtl.ts
@@ -1,30 +1,12 @@
 import type {APIRoute} from 'astro';
-import {experimental_AstroContainer as AstroContainer} from 'astro/container';
-import {loadRenderers} from 'astro:container';
-import {getContainerRenderer as getMDXRenderer} from '@astrojs/mdx/container-renderer';
 import PagePartialLayout from '../../layouts/PagePartialLayout.astro';
 import ArticlesListContent from '../../components/ArticlesListContent.astro';
+import {renderPartialResponse} from '../../utils/renderPartial.ts';
 
 export const GET: APIRoute = async () => {
-  const renderers = await loadRenderers([getMDXRenderer()]);
-  const container = await AstroContainer.create({renderers});
-
-  // Render the shared ArticlesListContent component
-  const articlesHtml = await container.renderToString(ArticlesListContent);
-
-  // Render the partial layout with the articles list as slot
-  const html = await container.renderToString(PagePartialLayout, {
-    props: {
-      title: 'Articles',
-    },
-    slots: {
-      default: articlesHtml,
-    },
-  });
-
-  return new Response(html, {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-    },
-  });
+  return renderPartialResponse(
+    PagePartialLayout,
+    {title: 'Articles'},
+    ArticlesListContent,
+  );
 };

--- a/src/pages/index.prtl.ts
+++ b/src/pages/index.prtl.ts
@@ -1,31 +1,15 @@
 import type {APIRoute} from 'astro';
-import {experimental_AstroContainer as AstroContainer} from 'astro/container';
-import {loadRenderers} from 'astro:container';
-import {getContainerRenderer as getMDXRenderer} from '@astrojs/mdx/container-renderer';
 import PagePartialLayout from '../layouts/PagePartialLayout.astro';
 import HomeContent from '../components/HomeContent.astro';
+import {renderPartialResponse} from '../utils/renderPartial.ts';
 
 export const GET: APIRoute = async () => {
-  const renderers = await loadRenderers([getMDXRenderer()]);
-  const container = await AstroContainer.create({renderers});
-
-  // Render the shared HomeContent component
-  const homeHtml = await container.renderToString(HomeContent);
-
-  // Render the partial layout with the home content as slot
-  const html = await container.renderToString(PagePartialLayout, {
-    props: {
+  return renderPartialResponse(
+    PagePartialLayout,
+    {
       title: 'Home',
       heading: 'Recent Articles',
     },
-    slots: {
-      default: homeHtml,
-    },
-  });
-
-  return new Response(html, {
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-    },
-  });
+    HomeContent,
+  );
 };

--- a/src/utils/articles.ts
+++ b/src/utils/articles.ts
@@ -1,0 +1,13 @@
+import {getCollection} from 'astro:content';
+
+/**
+ * Returns the static paths (and props) for every article, shared by the
+ * article page route and its partial endpoint.
+ */
+export async function getArticleStaticPaths() {
+  const articles = await getCollection('articles');
+  return articles.map((article) => ({
+    params: {slug: article.id},
+    props: {article},
+  }));
+}

--- a/src/utils/articles.ts
+++ b/src/utils/articles.ts
@@ -1,13 +1,14 @@
+import type {GetStaticPaths} from 'astro';
 import {getCollection} from 'astro:content';
 
 /**
  * Returns the static paths (and props) for every article, shared by the
  * article page route and its partial endpoint.
  */
-export async function getArticleStaticPaths() {
+export const getArticleStaticPaths = (async () => {
   const articles = await getCollection('articles');
   return articles.map((article) => ({
     params: {slug: article.id},
     props: {article},
   }));
-}
+}) satisfies GetStaticPaths;

--- a/src/utils/renderPartial.ts
+++ b/src/utils/renderPartial.ts
@@ -1,0 +1,34 @@
+import {experimental_AstroContainer as AstroContainer} from 'astro/container';
+import {loadRenderers} from 'astro:container';
+import {getContainerRenderer as getMDXRenderer} from '@astrojs/mdx/container-renderer';
+import type {AstroComponentFactory} from 'astro/runtime/server/index.js';
+
+/**
+ * Renders a partial layout (with the given props) whose default slot is the
+ * rendered `Content` component, and returns the result as an HTML `Response`.
+ */
+export async function renderPartialResponse(
+  Layout: AstroComponentFactory,
+  layoutProps: Record<string, unknown>,
+  Content: AstroComponentFactory,
+): Promise<Response> {
+  const renderers = await loadRenderers([getMDXRenderer()]);
+  const container = await AstroContainer.create({renderers});
+
+  // Render the content component to get its HTML.
+  const contentHtml = await container.renderToString(Content);
+
+  // Render the partial layout with the content HTML as its default slot.
+  const html = await container.renderToString(Layout, {
+    props: layoutProps,
+    slots: {
+      default: contentHtml,
+    },
+  });
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## Problem

The four partial endpoints were ~90% copy-paste of each other:

- `src/pages/index.prtl.ts`
- `src/pages/about/index.prtl.ts`
- `src/pages/articles/index.prtl.ts`
- `src/pages/articles/[...slug]/index.prtl.ts`

Each repeated the same sequence: `loadRenderers([getMDXRenderer()])`, `AstroContainer.create({renderers})`, `container.renderToString(<Content>)`, `container.renderToString(<PartialLayout>, {props, slots: {default: html}})`, and the `new Response(html, {headers: {'Content-Type': 'text/html; charset=utf-8'}})` wrapper. Additionally, the article `getStaticPaths` logic was duplicated verbatim between `src/pages/articles/[...slug].astro` and `src/pages/articles/[...slug]/index.prtl.ts`.

## Root cause

The partial-rendering pipeline was written inline in the first endpoint and then copied to the other three (and the article static-paths logic copied into the partial endpoint) instead of being factored into shared helpers.

## What changed

- New `src/utils/renderPartial.ts` exporting `renderPartialResponse(Layout, layoutProps, Content)`, which encapsulates renderer loading, container creation, both `renderToString` calls, and the `Response` wrapper. It's typed with `AstroComponentFactory` from `astro/runtime/server/index.js` (the same type/path the repo already uses in `src/astro.d.ts`). Placed under `src/utils/` (not `src/pages/`) so it doesn't become a route.
- New `src/utils/articles.ts` exporting `getArticleStaticPaths` (with `satisfies GetStaticPaths` so route-level props inference stays narrow), used by both `src/pages/articles/[...slug].astro` and `src/pages/articles/[...slug]/index.prtl.ts`.
- The four endpoints now shrink to imports plus a single `renderPartialResponse(...)` call each. Every endpoint's exact props are preserved: Home (`title: 'Home'`, `heading: 'Recent Articles'`), About (`title: 'About'`), Articles (`title: 'Articles'`), Article (`title`/`date`/`path`/`translations`).
- The article partial endpoint's awkward `Awaited<ReturnType<typeof getCollection>>[number]` cast is replaced with `CollectionEntry<'articles'>`.

`ArticlePartialLayout`/`PagePartialLayout` themselves are deliberately untouched — the sibling PR `fix/partial-title` modifies the layouts while this PR only touches the endpoints, so the two should not conflict.

**Note on `src/utils/articles.ts`:** sibling PR #110 (`fix/shared-helpers`) creates the same file on its branch with a different export (`getSortedArticles()`). This branch is off `origin/main`, where the file doesn't exist, so whichever PR merges second will see a trivial same-file conflict — the resolution is simply to keep both exports.

## Verification

- `npm run lint` — 0 errors
- `npm run types:check` — exit 0 (0 errors, 0 warnings)
- `npm run test:unit` — 16 test files, 67 tests, all passed
- `npm run build` — success
- **Byte-diff against `origin/main`** (the strongest signal for a pure refactor): built `origin/main` in the pristine `blog-baseline` worktree and this branch in its own worktree, then ran `diff -rq` over the **entire `dist/` directories** — this covers all 47 generated `*.prtl` files (the 3 page partials plus all 44 article partials) and every full HTML page, worker bundle, and asset. The only differing files were the two known build-time artifacts: `dist/atom.xml` (only the `<updated>` timestamp) and `dist/philipwalton/wrangler.json` (only the worktree `configPath`/`userConfigPath`). Everything else is byte-identical.
- Full e2e was **not** run: the e2e slot (ports 3000/3001) is occupied by another agent. `npm run test:integration` was also skipped for the same reason — `test/integration/worker.ts` targets `http://localhost:3000`, which requires the dev servers. This is acceptable here because the partial endpoints are fully static-generated, and the byte-diff proves all of their emitted output is unchanged — a stronger guarantee than e2e for a behavior-preserving refactor.

## Codex review

**APPROVE**, no blocking issues. Two low-severity suggestions:

1. `AstroComponentFactory` is imported from the internal-looking `astro/runtime/server/index.js` path — kept as-is because it matches the repo's existing convention in `src/astro.d.ts`.
2. Add explicit `GetStaticPaths` typing to the shared paths helper — applied via `satisfies GetStaticPaths` (which, unlike the old `: GetStaticPaths` annotation on the endpoint, doesn't widen the return type and keeps `props.article` inference intact).

## Please scrutinize

- The helper signature `renderPartialResponse(Layout, layoutProps, Content)` puts the layout first and content last; happy to reorder if you prefer content-first.
- `src/pages/articles/[...slug].astro` now does `export const getStaticPaths = getArticleStaticPaths;` — Astro's `Astro.props` inference from `getStaticPaths` still works with a re-exported const (verified by `astro check` passing with the untyped `const { article } = Astro.props;` destructure), but it's a slightly less common pattern than an inline function.
- The reconciliation plan with #110 for `src/utils/articles.ts` (keep both exports) needs to happen at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)