### PR TITLE
Ship partial titles as a data attribute instead of re-executed inline scripts

### DIFF
--- a/src/components/ArticleContent.astro
+++ b/src/components/ArticleContent.astro
@@ -9,9 +9,16 @@ interface Props {
   date: Date;
   path: string;
   translations?: Record<string, string> | undefined;
+  /**
+   * When rendered as a partial (via ArticlePartialLayout), the computed
+   * document title is emitted as a `data-document-title` attribute so the
+   * client-side content loader can update `document.title` after a
+   * SPA navigation. Omitted for full-page renders.
+   */
+  documentTitle?: string | undefined;
 }
 
-const { title, date, path, translations } = Astro.props;
+const { title, date, path, translations, documentTitle } = Astro.props;
 
 const baseUrl = 'https://philipwalton.com';
 
@@ -33,7 +40,7 @@ const shareText = `${title} ${shareUrl}`;
 const blueskyShareUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(shareText)}`;
 ---
 
-<article id="post" role="article" class="hentry">
+<article id="post" role="article" class="hentry" data-document-title={documentTitle}>
   <header class="ContentHeader">
     <h1 class="ContentHeader-articleTitle entry-title">{title}</h1>
     <div class="ContentHeader-meta">

--- a/src/javascript/content-loader.ts
+++ b/src/javascript/content-loader.ts
@@ -56,15 +56,37 @@ const fetchPageContent = async (pathname: string) => {
 };
 
 /**
- * Update the <main> element with the new content and set the new title.
+ * Update the <main> element with the new content.
  */
 const updatePageContent = (content: string) => {
   document.getElementById('content')!.innerHTML = content;
 };
 
 /**
- * Executes any scripts added to the container element since they're not
- * automatically added via `innerHTML`.
+ * Updates `document.title` from the loaded partial content.
+ *
+ * The partial layouts (`ArticlePartialLayout.astro` and
+ * `PagePartialLayout.astro`) emit the computed document title as a
+ * `data-document-title` attribute on their root element. If the attribute
+ * is not present for any reason, the current title is left unchanged.
+ */
+const updateDocumentTitle = () => {
+  const title = document
+    .getElementById('content')!
+    .querySelector('[data-document-title]')
+    ?.getAttribute('data-document-title');
+
+  if (title) {
+    document.title = title;
+  }
+};
+
+/**
+ * Re-executes any <script> elements found in the container element, since
+ * scripts added via `innerHTML` do not run. This is still needed for
+ * articles that embed live demo scripts in their MDX content (e.g.
+ * `why-web-developers-need-to-care-about-interactivity.mdx`), so those
+ * demos keep working after a SPA navigation.
  */
 const executeContainerScripts = () => {
   const container = document.getElementById('content')!;
@@ -116,6 +138,7 @@ export const loadPage = async (url: URL, event?: NavigateEvent) => {
     window.scrollTo(0, state?.scrollY ?? 0);
   }
   updatePageContent(content);
+  updateDocumentTitle();
   executeContainerScripts();
   linkableHeadings.init();
 };

--- a/src/layouts/ArticlePartialLayout.astro
+++ b/src/layouts/ArticlePartialLayout.astro
@@ -18,10 +18,12 @@ const titleSuffix = ' — Philip Walton';
 const documentTitle = `${title}${titleSuffix}`;
 ---
 
-<ArticleContent title={title} date={date} path={path} translations={translations}>
+<ArticleContent
+  title={title}
+  date={date}
+  path={path}
+  translations={translations}
+  documentTitle={documentTitle}
+>
   <slot />
 </ArticleContent>
-
-<script is:inline define:vars={{ documentTitle }}>
-  document.title = documentTitle;
-</script>

--- a/src/layouts/PagePartialLayout.astro
+++ b/src/layouts/PagePartialLayout.astro
@@ -20,13 +20,9 @@ const site = {
 const documentTitle = title ? `${title}${site.titleSuffix}` : site.title;
 ---
 
-<article id="post" role="article" class="hentry">
+<article id="post" role="article" class="hentry" data-document-title={documentTitle}>
   <header class="ContentHeader">
     <h1 class="ContentHeader-pageTitle">{heading}</h1>
   </header>
   <slot />
 </article>
-
-<script is:inline define:vars={{ documentTitle }}>
-  document.title = documentTitle;
-</script>


### PR DESCRIPTION
## Problem

After every SPA navigation, `content-loader.ts` strips every `<script>` tag out of the fetched partial and re-injects it just so the browser will execute it (`executeContainerScripts()`, `src/javascript/content-loader.ts`). The primary reason those scripts exist at all is the inline `<script is:inline define:vars={{documentTitle}}>document.title = documentTitle;</script>` blocks emitted by `src/layouts/ArticlePartialLayout.astro` and `src/layouts/PagePartialLayout.astro` — running a script on every route change just to set `document.title` (recommendations.md #14).

## Root cause

The partial layouts had no way to communicate the computed page title to the client-side loader other than embedding executable code in the partial, which `innerHTML` doesn't run, which in turn forced the strip-and-re-inject machinery.

## What changed

- `ArticlePartialLayout.astro` / `PagePartialLayout.astro`: the inline `define:vars` title scripts are removed. The computed title is now emitted as a `data-document-title` attribute on the partial's root `<article>` element (for articles, via a new optional `documentTitle` prop on `ArticleContent.astro`; the attribute is omitted on full-page renders).
- `content-loader.ts`: a new `updateDocumentTitle()` reads that attribute after the content is swapped in and sets `document.title` from it. If the attribute is missing or empty (e.g. an unexpected partial shape), the current title is left unchanged. A comment documents the contract with the partial layouts.

**Deliberate deviation from recommendations.md #14:** the recommendation (and this task's brief) assumed the title scripts were the *only* scripts partials ever contain and asked for `executeContainerScripts()` to be deleted. That premise is false: `src/content/articles/why-web-developers-need-to-care-about-interactivity.mdx` (line 162) embeds a live `<script>` powering its "Block the main thread" demo, which only works after SPA navigations because of the re-injection. `executeContainerScripts()` is therefore retained (with an updated comment explaining why); the title scripts it existed for are still gone.

## Verification

- `npm run lint` — 0 errors
- `npm run types:check` — pass
- `npm run test:unit` — 16 files / 67 tests pass
- `npm run build` — pass; verified every built `dist/**/index.prtl` carries `data-document-title`, contains no title script, and full-page HTML is unchanged
- `npm test` (full e2e) — all title-asserting SPA-navigation tests pass (`content-loading.ts` "load page partials", "back and forward buttons"; `log.ts` SPA pageview tests). Remaining failures were verified pre-existing by re-running the full suite on a clean `origin/main` checkout on the same machine:
  - `homepage.ts` "working links to all published articles" — known atom-feed order bug (fails at the heading/feed-order comparison, not at a title assertion; fix pending in a separate PR)
  - `content-loading.ts` "should not attempt to load non-HTML content" — known deterministic failure on main (feed order → article without a figure image)
  - `content-loading.ts` "should show an error if the content cannot be loaded" — known intermittent; passed 6/9 in repeated runs of the spec on this branch
  - `log.ts` "should track engagement time" — fails identically on `origin/main` in this environment (engagement only accrues when the automated Chrome window has focus; see also recommendations.md #2's `_state === null` dead branch)

## Codex review

**APPROVE.** Non-blocking suggestions:
- Use `title !== null` instead of `if (title)` so an empty attribute still applies. Deliberately not taken: an empty computed title should leave the current title rather than blank the tab.
- Add SPA-navigation title test coverage — already exists in e2e (`waitUntil(title == expected)` in `content-loading.ts`/`log.ts`); codex only saw the diff.

## Please scrutinize

- **Contract change for scripts (softened but real):** on SPA navigations the document title is now taken from `data-document-title` *before* any partial scripts run. If you ever emit a partial without the attribute, the stale previous title persists silently. Full page loads are unaffected.
- **`executeContainerScripts()` retained, contrary to the original recommendation** — if you'd rather delete it as recommendations.md #14 suggests, be aware that breaks the "Block the main thread" demo in the interactivity article after SPA navigations (full loads unaffected). Deleting it would then make any future live `<script>` in MDX content silently inert on SPA navigations — that trade-off is yours to make; this PR keeps current behavior.
- **Conflicts with sibling PRs:** #116 (fix/nav-guards) also modifies `content-loader.ts` (and `test/e2e/content-loading.ts`) — whichever merges second rebases. #108 (fix/site-config) touches the same partial-layout frontmatter (title string source) — trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)