### PR TITLE
Refresh Logger page params (dl/dt) on SPA navigations

### DIFF
--- a/src/javascript/Logger.test.ts
+++ b/src/javascript/Logger.test.ts
@@ -99,7 +99,9 @@ describe('Logger', () => {
     try {
       const logger = new Logger();
       await logger.event('event_1');
-      expect(lastBeacon().pageParams.get('dl')).toBe(originalUrl);
+
+      const firstBeacon = lastBeacon();
+      expect(firstBeacon.pageParams.get('dl')).toBe(originalUrl);
 
       // Simulate an SPA navigation.
       history.pushState({}, '', '/spa-page/');
@@ -108,9 +110,17 @@ describe('Logger', () => {
       logger.refreshPageParams();
       await logger.event('event_2');
 
-      const {pageParams} = lastBeacon();
-      expect(new URL(pageParams.get('dl')!).pathname).toBe('/spa-page/');
-      expect(pageParams.get('dt')).toBe('SPA Page');
+      const beacon = lastBeacon();
+      expect(new URL(beacon.pageParams.get('dl')!).pathname).toBe('/spa-page/');
+      expect(beacon.pageParams.get('dt')).toBe('SPA Page');
+
+      // Events logged after the refresh start a new beacon, and the beacon
+      // containing the pre-navigation events is left scheduled (not
+      // aborted), so those events keep the params from when they were
+      // logged.
+      expect(beacon.pageParams.get('_s')).toBe('2');
+      expect(beacon.events.map((e) => e.get('en'))).toEqual(['event_2']);
+      expect(firstBeacon.init.signal!.aborted).toBe(false);
     } finally {
       history.replaceState({}, '', originalUrl);
       document.title = originalTitle;

--- a/src/javascript/Logger.test.ts
+++ b/src/javascript/Logger.test.ts
@@ -107,7 +107,7 @@ describe('Logger', () => {
       history.pushState({}, '', '/spa-page/');
       document.title = 'SPA Page — Site Name';
 
-      logger.refreshPageParams();
+      await logger.refreshPageParams();
       await logger.event('event_2');
 
       const beacon = lastBeacon();
@@ -125,6 +125,35 @@ describe('Logger', () => {
       history.replaceState({}, '', originalUrl);
       document.title = originalTitle;
     }
+  });
+
+  it('keeps in-flight events in the pre-refresh beacon group', async () => {
+    const logger = new Logger();
+
+    // Add a presend dependency that doesn't resolve until later, so
+    // events are held in-flight (not yet queued) when the refresh occurs.
+    let resolveDependency!: () => void;
+    logger.awaitBeforeSending(
+      new Promise<void>((r) => (resolveDependency = r)),
+    );
+
+    const event1Done = logger.event('event_1');
+    const refreshDone = logger.refreshPageParams();
+    const event2Done = logger.event('event_2');
+
+    resolveDependency();
+    await Promise.all([event1Done, refreshDone, event2Done]);
+
+    // event_1 was logged before the refresh, so it must remain in the
+    // first beacon group, which must not be aborted.
+    const [, firstInit] = fetchLaterMock.mock.calls.at(0)!;
+    expect(String(firstInit!.body)).toContain('en=event_1');
+    expect(firstInit!.signal!.aborted).toBe(false);
+
+    // event_2 was logged after the refresh, so it starts a new beacon.
+    const beacon = lastBeacon();
+    expect(beacon.pageParams.get('_s')).toBe('2');
+    expect(beacon.events.map((e) => e.get('en'))).toEqual(['event_2']);
   });
 
   it('batches queued events, aborting the superseded beacon', async () => {

--- a/src/javascript/Logger.test.ts
+++ b/src/javascript/Logger.test.ts
@@ -92,6 +92,31 @@ describe('Logger', () => {
     expect(event!.get('ep.page_path')).toBe('/custom');
   });
 
+  it('refreshes the dl and dt params via refreshPageParams()', async () => {
+    const originalUrl = location.href;
+    const originalTitle = document.title;
+
+    try {
+      const logger = new Logger();
+      await logger.event('event_1');
+      expect(lastBeacon().pageParams.get('dl')).toBe(originalUrl);
+
+      // Simulate an SPA navigation.
+      history.pushState({}, '', '/spa-page/');
+      document.title = 'SPA Page — Site Name';
+
+      logger.refreshPageParams();
+      await logger.event('event_2');
+
+      const {pageParams} = lastBeacon();
+      expect(new URL(pageParams.get('dl')!).pathname).toBe('/spa-page/');
+      expect(pageParams.get('dt')).toBe('SPA Page');
+    } finally {
+      history.replaceState({}, '', originalUrl);
+      document.title = originalTitle;
+    }
+  });
+
   it('batches queued events, aborting the superseded beacon', async () => {
     const logger = new Logger();
     await logger.event('event_1');

--- a/src/javascript/Logger.ts
+++ b/src/javascript/Logger.ts
@@ -173,6 +173,15 @@ export class Logger {
    * (document location and title) to reflect the current page.
    */
   refreshPageParams() {
+    // If any events are queued, start a new beacon and leave the pending
+    // one scheduled (not aborted), so already-logged events are sent with
+    // the page params that were current when they were logged.
+    if (this._eventQueue.size > 0) {
+      this._sendCount++;
+      this._eventQueue.clear();
+      delete this._fetchLaterResult;
+      delete this._fetchLaterController;
+    }
     this._pageParams.dl = location.href;
     this._pageParams.dt = getPageTitle();
   }

--- a/src/javascript/Logger.ts
+++ b/src/javascript/Logger.ts
@@ -53,7 +53,7 @@ export class Logger {
 
     this._pageParams = {
       dl: location.href,
-      dt: document.title.replace(/\s+—.*$/, ''),
+      dt: getPageTitle(),
       de: document.characterSet,
       ul: navigator.language.toLowerCase(),
       vp: `${innerWidth}x${innerHeight}`,
@@ -166,6 +166,15 @@ export class Logger {
    */
   set(params: Params) {
     Object.assign(this._eventParams, params);
+  }
+
+  /**
+   * Updates the page params that can change after an SPA navigation
+   * (document location and title) to reflect the current page.
+   */
+  refreshPageParams() {
+    this._pageParams.dl = location.href;
+    this._pageParams.dt = getPageTitle();
   }
 
   /**
@@ -402,6 +411,13 @@ function toQueryString(params: Params): string {
       return `${key}=${encodeURIComponent(value)}`;
     })
     .join('&');
+}
+
+/**
+ * Gets the document title with the site name suffix removed.
+ */
+function getPageTitle(): string {
+  return document.title.replace(/\s+—.*$/, '');
 }
 
 /**

--- a/src/javascript/Logger.ts
+++ b/src/javascript/Logger.ts
@@ -172,7 +172,15 @@ export class Logger {
    * Updates the page params that can change after an SPA navigation
    * (document location and title) to reflect the current page.
    */
-  refreshPageParams() {
+  async refreshPageParams() {
+    const dl = location.href;
+    const dt = getPageTitle();
+
+    // Wait for any in-flight events to be queued first. Since `event()`
+    // awaits these same dependencies before queuing, all events logged
+    // before this method was called are queued before it continues.
+    await Promise.all(this._presendDependencies);
+
     // If any events are queued, start a new beacon and leave the pending
     // one scheduled (not aborted), so already-logged events are sent with
     // the page params that were current when they were logged.
@@ -182,8 +190,8 @@ export class Logger {
       delete this._fetchLaterResult;
       delete this._fetchLaterController;
     }
-    this._pageParams.dl = location.href;
-    this._pageParams.dt = getPageTitle();
+    this._pageParams.dl = dl;
+    this._pageParams.dt = dt;
   }
 
   /**

--- a/src/javascript/content-loader.ts
+++ b/src/javascript/content-loader.ts
@@ -85,13 +85,15 @@ const executeContainerScripts = () => {
  * Updates log to reflect the current page.
  */
 const trackPageview = async (url: URL) => {
+  log.set({page_path: url.pathname});
+
   // Update the page-level `dl` and `dt` params to reflect the new URL and
   // title. This runs after `loadPage()`, so `document.title` has already
   // been updated by the partial's container script. Events logged before
   // this point (e.g. `route_transition`) remain in a beacon that keeps
   // the pre-navigation `dl`/`dt`.
-  log.refreshPageParams();
-  log.set({page_path: url.pathname});
+  await log.refreshPageParams();
+
   log.event('page_view', {
     navigation_type: 'route_change',
     visibility_state: document.visibilityState,

--- a/src/javascript/content-loader.ts
+++ b/src/javascript/content-loader.ts
@@ -85,6 +85,12 @@ const executeContainerScripts = () => {
  * Updates log to reflect the current page.
  */
 const trackPageview = async (url: URL) => {
+  // Update the page-level `dl` and `dt` params to reflect the new URL and
+  // title. This runs after `loadPage()`, so `document.title` has already
+  // been updated by the partial's container script. Note: the earlier
+  // `route_transition` event intentionally reports the pre-navigation
+  // `dl`/`dt`, since the previous page is still displayed when it's logged.
+  log.refreshPageParams();
   log.set({page_path: url.pathname});
   log.event('page_view', {
     navigation_type: 'route_change',

--- a/src/javascript/content-loader.ts
+++ b/src/javascript/content-loader.ts
@@ -87,9 +87,9 @@ const executeContainerScripts = () => {
 const trackPageview = async (url: URL) => {
   // Update the page-level `dl` and `dt` params to reflect the new URL and
   // title. This runs after `loadPage()`, so `document.title` has already
-  // been updated by the partial's container script. Note: the earlier
-  // `route_transition` event intentionally reports the pre-navigation
-  // `dl`/`dt`, since the previous page is still displayed when it's logged.
+  // been updated by the partial's container script. Events logged before
+  // this point (e.g. `route_transition`) remain in a beacon that keeps
+  // the pre-navigation `dl`/`dt`.
   log.refreshPageParams();
   log.set({page_path: url.pathname});
   log.event('page_view', {

--- a/test/e2e/log.ts
+++ b/test/e2e/log.ts
@@ -346,9 +346,20 @@ describe('log', function () {
         return title.includes(pages[1]?.title || '');
       });
 
+      // Each SPA navigation finalizes the pending beacon (so its events
+      // keep the pre-navigation page params) and its events are not re-sent
+      // in later beacons, so wait for each navigation's beacon to be
+      // received before navigating again.
+      await browser.waitUntil(() => {
+        return beaconsContain({
+          'en': 'page_view',
+          'ep.page_path': pages[1]?.path || '',
+          'ep.navigation_type': 'route_change',
+        });
+      });
+
       // Click 'back' to the home page
 
-      await clearBeacons();
       await browser.back();
       // await browser.pause(1000);
       await browser.waitUntil(async () => {
@@ -356,9 +367,16 @@ describe('log', function () {
         return title.includes(pages[0]?.title || '');
       });
 
+      await browser.waitUntil(() => {
+        return beaconsContain({
+          'en': 'page_view',
+          'ep.page_path': pages[0]?.path || '',
+          'ep.navigation_type': 'route_change',
+        });
+      });
+
       // Click 'forward' to the articles page
 
-      await clearBeacons();
       await browser.forward();
       // await browser.pause(1000);
       await browser.waitUntil(async () => {

--- a/test/e2e/log.ts
+++ b/test/e2e/log.ts
@@ -316,6 +316,8 @@ describe('log', function () {
 
       await browser.waitUntil(() => {
         return beaconsContain({
+          // After an SPA navigation, `dl` should reflect the new URL.
+          'dl': new RegExp(`${articles[0]?.path}$`),
           'en': 'page_view',
           'ep.page_path': articles[0]?.path || '',
           'ep.original_page_path': '/',


### PR DESCRIPTION
## Problem

`Logger` captures `dl` (`location.href`) and `dt` (`document.title`) once at construction (`src/javascript/Logger.ts`, `_pageParams` init, ~lines 54-56). After an SPA navigation (`src/javascript/content-loader.ts`), subsequent beacons carry the updated event-level `ep.page_path` but the *original* document location and title in the page-level `dl`/`dt` params. Since the analytics design already tracks `original_page_path` separately (`src/javascript/log.ts`), the stale `dl`/`dt` appears to be an oversight rather than intent.

## Root cause

`_pageParams.dl` and `_pageParams.dt` were only ever written in the constructor; nothing updated them when the SPA content loader swapped the page.

## What changed

- **`src/javascript/Logger.ts`**
  - New public `refreshPageParams()` method that re-reads `location.href` and the (suffix-stripped) `document.title` into `dl`/`dt`. The title-stripping one-liner is factored into a `getPageTitle()` helper so the `/\s+—.*$/` regex isn't duplicated.
  - Because the beacon body is rebuilt from the mutable `_pageParams` on every `_queue()` call, simply mutating `dl`/`dt` would have relabeled *already-queued but unsent* events with the new page's params. So `refreshPageParams()` also **rotates the beacon group**: it leaves the pending `fetchLater()` beacon scheduled (deliberately *not* aborted, unlike the superseded-beacon path in `_queue()`) and starts a new group (`_sendCount++`, clear queue, drop the result/controller references). Events keep the page params that were current when they were logged; this reuses the same rotation mechanism `_queue()` already applies after a beacon activates.
  - `refreshPageParams()` captures `dl`/`dt` synchronously, then awaits `_presendDependencies` before rotating. Since `event()` awaits the same promises before queuing, microtask FIFO ordering guarantees every event logged *before* the refresh call is queued into the old group and every event logged after lands in the new one — closing an in-flight-event race flagged in review.
- **`src/javascript/content-loader.ts`** — `trackPageview()` calls `log.refreshPageParams()` before logging the `page_view`. This runs after `loadPage()`, i.e. after `executeContainerScripts()` has applied the partial's `document.title`. **Deliberate choice:** the earlier `route_transition` event (logged in `fetchPageContent()`, before the content is swapped) keeps the *pre-navigation* `dl`/`dt` — that's the document state at the time it's logged — while `page_view` and everything after report the new URL/title. The beacon rotation is what makes this guarantee hold.
- **`src/javascript/Logger.test.ts`** — two new browser-project unit tests: one simulates an SPA navigation (`history.pushState` + `document.title` assignment) and asserts the next beacon's `dl`/`dt`, `_s` bump, and that the pre-refresh beacon is left un-aborted with its events; another covers the in-flight race (event logged while a presend dependency is pending, then refresh) and asserts the event stays in the pre-refresh group.
- **`test/e2e/log.ts`** — encodes the new intended semantics:
  - "should send pageview hits on SPA pageloads" now asserts the post-navigation beacon's `dl` matches the *new* article URL.
  - "should send pageview hits on back/forward navigations": removed the two intermediate `clearBeacons()` calls and instead waits for each navigation's `page_view` beacon (matched by `navigation_type: route_change`) before navigating again. The old test implicitly depended on the abort-and-resend batching behavior (cleared events reappeared in the final rebuilt beacon); with rotation, each navigation finalizes its beacon and events are not re-sent, and the per-step waits also make the final in-order triple assertion deterministic.

## Verification

All run inside the worktree on this branch:

- `npm run lint` — 0 errors
- `npm run types:check` — pass
- `npm run test:unit` — 16 files / 69 tests pass (includes the 2 new Logger tests)
- `npm run build` — pass
- `npm test` (full e2e, multiple runs) — all log.ts tests pass, including both SPA specs with the new assertions. Tolerated failures observed, all pre-existing/known:
  - `homepage.ts` "working links to all published articles" — deterministic (atom-feed order, PR #103)
  - `content-loading.ts` "should not attempt to load non-HTML content" — deterministic (same root cause)
  - `content-loading.ts` "should show an error if the content cannot be loaded" — intermittent, passes on retry
  - `log.ts` "should track engagement time" — environmental on the test machine (needs browser window focus); passed when the window had focus
  - `worker.ts` priority-hints specs intermittently timed out (in `clearStorage()`'s `/__reset` readiness wait) in some full-suite runs and passed in others, with identical code. Running the spec alone 4x showed the same first-attempt flake (~1 min hang) that always passes on the automatic retry, so it's a pre-existing timing flake. `refreshPageParams()` is only invoked on SPA navigations, which worker.ts never performs, so this diff's code path is never exercised there.

## Codex review

Three rounds (read-only):

- Round 1: REQUEST_CHANGES — flagged that mutating `dl`/`dt` in place would relabel already-queued events (and made the route_transition comment false). **Fixed** via the beacon-group rotation described above.
- Round 2: REQUEST_CHANGES — flagged the in-flight `event()` race (event logged pre-refresh but queued post-refresh while awaiting presend dependencies). **Fixed** by awaiting the same presend dependencies in `refreshPageParams()`; regression unit test added.
- Round 3: **APPROVE**, no blocking issues. Its suggestion to make the refresh/`page_view` sequencing explicit was adopted (`trackPageview()` now `await`s the refresh).

Unresolved non-blocking suggestions: (a) `new RegExp(`${articles[0]?.path}$`)` in the e2e spec doesn't regex-escape the path — current article slugs contain no regex-significant characters, and this matches the file's existing `new RegExp(...)` usage; (b) the in-flight-race unit test asserts grouping (`_s`, un-aborted first beacon) but doesn't additionally change the URL/title within that test — the dl/dt values themselves are covered by the other new test; (c) explicit `: void`/return-type annotations on the new method were skipped to match the class's existing style.

## Please scrutinize

- **This changes analytics semantics.** If the stale `dl`/`dt` was intentional (e.g. GA-style "dl = the originally loaded document"), close this PR — the source report flagged this issue as "verify against intent". Note `original_page_path` already preserves the landing path at the event level.
- **Beacon delivery granularity changed for SPA sessions**: previously one beacon body was continuously rebuilt (abort + reschedule) across SPA navigations; now each SPA navigation finalizes the pending beacon and starts a new one, so multi-page SPA sessions send one beacon per page rather than one combined beacon. `_s` (send count) increments per navigation accordingly, and `/log` ingestion will see more, smaller requests. Verify this is acceptable for the collection endpoint.
- The `route_transition` event intentionally keeps the pre-navigation `dl`/`dt` (document state at log time); if you'd rather it carry the destination's params, move the `refreshPageParams()` call earlier.
- The e2e back/forward test rewrite (dropping intermediate `clearBeacons()`) encodes the new no-resend semantics — please confirm the test still checks what you intended it to.

## Conflicts with sibling PRs

- PR #106 (`fix/logger-state-init`) touches `Logger.ts` (different method — constructor/state init).
- PRs #116/#117 touch `content-loader.ts`; #117 modifies `loadPage()` near `trackPageview()`. This diff adds only one call + comment inside `trackPageview()`, so rebases should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
