### PR TITLE
Clean up breakpoints mql typing and remove dead content-loader code

### DIFF
--- a/src/javascript/breakpoints.ts
+++ b/src/javascript/breakpoints.ts
@@ -1,7 +1,10 @@
 interface Breakpoint {
   name: string;
   media: string;
-  mql?: MediaQueryList;
+}
+
+interface BreakpointWithMql extends Breakpoint {
+  mql: MediaQueryList;
 }
 
 export const breakpoints: Breakpoint[] = [
@@ -9,6 +12,10 @@ export const breakpoints: Breakpoint[] = [
   {name: 'md', media: '(min-width: 36em)'},
   {name: 'lg', media: '(min-width: 48em)'},
 ];
+
+// Populated by `init()`, pairing each breakpoint with its live
+// MediaQueryList.
+let breakpointsWithMql: BreakpointWithMql[] = [];
 
 // Set a default initially, which will be overridden at `init()` time
 // if anything matches.
@@ -19,8 +26,8 @@ let activeBreakpoint: Breakpoint = breakpoints[0]!;
  * media query and stores that on the `activeBreakpoint` variable.
  */
 function handleChanges() {
-  for (const breakpoint of breakpoints) {
-    if (breakpoint.mql!.matches) {
+  for (const breakpoint of breakpointsWithMql) {
+    if (breakpoint.mql.matches) {
       activeBreakpoint = breakpoint;
     }
   }
@@ -31,13 +38,12 @@ function handleChanges() {
  * current active breakpoint.
  */
 export function init() {
-  for (const breakpoint of breakpoints) {
-    breakpoint.mql = window.matchMedia(breakpoint.media);
-    breakpoint.mql.addEventListener('change', handleChanges);
-    if (breakpoint.mql!.matches) {
-      activeBreakpoint = breakpoint;
-    }
-  }
+  breakpointsWithMql = breakpoints.map((breakpoint) => {
+    const mql = window.matchMedia(breakpoint.media);
+    mql.addEventListener('change', handleChanges);
+    return {...breakpoint, mql};
+  });
+  handleChanges();
 }
 
 /**

--- a/src/javascript/content-loader.ts
+++ b/src/javascript/content-loader.ts
@@ -92,20 +92,6 @@ const trackPageview = async (url: URL) => {
   });
 };
 
-// /**
-//  * Sets the scroll position of the main document to the top of the page or
-//  * to the position of an element if a hash fragment is passed.
-//  */
-// const setScroll = (hash) => {
-//   const target = hash && document.getElementById(hash.slice(1));
-//   const scrollPos = target ? target.offsetTop : 0;
-
-//   // TODO: There's a weird bug were sometimes this function doesn't do anything
-//   // if the browser has already visited the page and thinks it has a scroll
-//   // position in mind.
-//   window.scrollTo(0, scrollPos);
-// };
-
 /**
  * Loads a page partial for the passed pathname and updates the content.
  */
@@ -121,8 +107,8 @@ export const loadPage = async (url: URL, event?: NavigateEvent) => {
 };
 
 /**
- * Disables the history2 instance, which forces a full page load on the next
- * link click.
+ * Disables the SPA content loader, which forces a full page load on the
+ * next link click.
  */
 export const disableLoader = () => {
   isLoaderDisabled = true;


### PR DESCRIPTION
## Problem

- `src/javascript/breakpoints.ts`: the `Breakpoint` interface declares `mql?: MediaQueryList` as optional, then every read site non-null-asserts it (`breakpoint.mql!.matches`) because in practice `init()` always populates it before it's read. The optional type plus scattered `!` assertions obscure the actual invariant and defeat the type checker.
- `src/javascript/content-loader.ts`:
  - The doc comment on `disableLoader()` (line ~124) refers to "the history2 instance," which no longer exists in this codebase.
  - There's a fully commented-out `setScroll` function (~lines 95-107), including a stale `// TODO`, left dead in the file.

## Root cause

Leftover artifacts from earlier refactors: `mql` was made optional because it's assigned after the array literal is created, and nobody went back to tighten the type once `init()` became the sole populator. The `history2` comment and `setScroll` block are holdovers from a prior implementation that's since been replaced.

## What changed

1. `breakpoints.ts`: split the type into a public `Breakpoint` (`{name, media}`, the source-of-truth list shape) and an internal `BreakpointWithMql` (`Breakpoint & {mql: MediaQueryList}`). `init()` now builds a module-level `breakpointsWithMql` array via `breakpoints.map(...)`, so `mql` is guaranteed present wherever it's read — no `!` assertions remain. The exported API (`breakpoints`, `init()`, `getActiveBreakpoint()`) is unchanged; all call sites (`main.ts`'s `breakpoints.init()`, `Logger.ts`'s `getActiveBreakpoint().name`) work as-is.
2. `content-loader.ts`: reworded the `disableLoader()` comment to describe what it actually does (disables the SPA content loader / forces a full page load on next link click) instead of referencing the nonexistent "history2 instance." Deleted the entire commented-out `setScroll` block and its TODO.
3. Per instructions, did **not** add the `xl` breakpoint — that's sibling PR #114 (`fix/breakpoints-xl`)'s job.

## Verification

All run inside an isolated worktree/branch (`fix/js-cleanups` off `origin/main`):
- `npm run lint` — 0 errors.
- `npm run types:check` (astro check + tsc) — 0 errors (pre-existing unrelated `env` deprecation hints in `src/worker/performance.test.ts` only).
- `npm run test:unit` — 16 test files / 67 tests passed, including `breakpoints.test.ts` unchanged (it only exercises `init()`/`getActiveBreakpoint()`, not the internal `mql` field, so no test changes were needed).
- `npm run build` — succeeded, 48 pages built.
- E2E was not run per task instructions (lint/types/unit/build only).

## Codex review

Ran `git diff origin/main...HEAD | codex exec --sandbox read-only --ephemeral ...`. **Verdict: APPROVE**, no blocking issues. Two non-blocking low-severity notes, both judged as expected/no-op given the task scope:
- `init()` is still not idempotent (re-running it adds more `change` listeners) — this matches pre-existing behavior; not a regression.
- `activeBreakpoint` now points to a copied `{...breakpoint, mql}` object rather than an original `breakpoints` array entry — current callers only read `.name`, so this is safe, but noting it for anyone relying on object identity in the future.

## Please scrutinize

- The internal restructuring approach (module-level `breakpointsWithMql` array built via `.map()` in `init()`) is one of a few reasonable designs the task allowed ("whatever is cleanest") — please confirm this style fits your preference over alternatives (e.g., a `WeakMap`, or storing `mql` in a closure per breakpoint).
- **Known conflict**: `breakpoints.ts` will conflict with sibling PR #114 (`fix/breakpoints-xl`), which adds an `xl` entry to the `breakpoints` list — that's a trivial one-line addition to rebase.
- **Known conflict**: `content-loader.ts` will conflict with sibling PRs #116/#117/#118, which touch other regions of the same file — this comment/dead-code removal should rebase trivially since it doesn't overlap their edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)