### PR TITLE
Run e2e spec files serially to eliminate cross-spec flakiness

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -46,7 +46,10 @@ export const config = {
   // and 30 processes will get spawned. The property handles how many capabilities
   // from the same test should run tests.
   //
-  maxInstances: 10,
+  // Run spec files serially: parallel workers share the beacon/log server
+  // state on port 3001 and flake. See issue #123 for restoring
+  // parallelism once specs are isolated.
+  maxInstances: 1,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:


### PR DESCRIPTION
## Problem

The e2e suite flakes when spec files run in parallel (`maxInstances: 10`): intermittently failing tests include content-loading's error-alert test, worker's priority-hints test, and log's engagement-time test (the latter failed consistently in parallel full-suite runs on this machine).

## Root cause (working hypothesis — investigation tracked in #123)

Parallel spec workers interfere through shared state: all specs read/clear the same beacon/log store on port 3001 (`test/e2e/utils/beacons.ts` has no per-worker namespacing), and concurrent Chrome windows compete for document focus, which breaks the engagement-time test (Logger only accrues engaged time while focused).

## What changed

`wdio.conf.js`: `maxInstances: 10` → `1`, with a comment pointing at #123 for restoring parallelism once specs are isolated. (Change originated from Philip's local testing; packaged and verified here.)

## Verification

- Two consecutive full `npm test` runs on this branch (which includes the merged #121 workaround and #103 feed fix): **5/5 spec files, 100%, zero retries, both runs** — including the engagement-time test that reliably failed in parallel runs.
- Wall-clock cost: ~33s serial vs ~18s parallel for the current 5 specs.

## Codex review

APPROVE. Its one LOW note (comment should cite the tracking issue number) was addressed — the comment now references #123.

## Please scrutinize

- Whether you'd prefer a narrower fix now (e.g. grouping only `log.ts` into a serial bucket and keeping the rest parallel) — I went with your tested change as-is; #123 covers the finer-grained options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)