### PR TITLE
Clear stale priority hints for both fixture pages in the worker e2e test

### DIFF
--- a/test/e2e/worker.ts
+++ b/test/e2e/worker.ts
@@ -12,7 +12,7 @@ describe('worker', function () {
       // Delete the cache by passing an empty selector.
       // TODO: figure out a better way to do this. There doesn't seem to
       // currently be a way to clear KV store data locally via wrangler.
-      for (const url of [urlWithLCPImage, urlWithLCPImage]) {
+      for (const url of [urlWithLCPImage, urlWithoutLCPImage]) {
         await fetch(`http://localhost:3000/hint`, {
           method: 'POST',
           body: JSON.stringify({


### PR DESCRIPTION
## Summary

The worker e2e test's `beforeEach` clears the priority-hint KV entry with `[urlWithLCPImage, urlWithLCPImage]` — a copy-paste bug (present since the test was added in a5a02f5) that clears the LCP page twice and never clears `urlWithoutLCPImage`.

Because `wrangler dev` persists local KV in `.wrangler/state` across sessions, a single real-browser load of `/articles/cascading-cache-invalidation/` that happens to get an image LCP beacons a `POST /hint` with a real selector — and from that moment on, "should not apply priority hints to prior non-LCP images" fails deterministically with `'high' !== null` on every attempt (wdio retries can't help since all attempts see the same store).

This never shows up in CI, which starts from a clean checkout with empty KV state — it only bites local machines once their store gets poisoned.

## Verification

Bisected under identical seeded stale state at the worker's HTTP surface:
- Seeded a stale hint for the non-LCP page → worker injects `fetchpriority="high"` into its first `<img>` (reproduces the exact failure)
- Old code + seeded state → suite fails on all 3 attempts, byte-for-byte the observed failure
- Fixed code + same seeded state → `2 passing (2.4s)`
- Two further consecutive runs (inheriting real KV state from prior runs) → the fixed test passes every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)